### PR TITLE
fix(extra yazi): replace deprecated `manager` table

### DIFF
--- a/lua/tokyonight/extra/yazi.lua
+++ b/lua/tokyonight/extra/yazi.lua
@@ -7,7 +7,7 @@ function M.generate(colors)
   colors.bg_search = util.blend_bg(colors.info, 0.1)
   local yazi = util.template(
     [[
-[manager]
+[mgr]
 # NOTE: can combined with tmTheme (sublime colorshceme file) for preview code highlight
 # syntect_theme = "path/to/tmTheme"
 


### PR DESCRIPTION
The `manager` table has been deprecated in favour of `mgr`, which should be a direct replacement.

This is documented here: <https://github.com/sxyazi/yazi/pull/2803>

## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

